### PR TITLE
Adds travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+xcode_project: Example/Punycode.xcodeproj
+xcode_scheme: PunycodeTests

--- a/Example/Punycode.xcodeproj/xcshareddata/xcschemes/PunyCocoa.xcscheme
+++ b/Example/Punycode.xcodeproj/xcshareddata/xcschemes/PunyCocoa.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B2D4E99208E0191700574ACD"
+               BuildableName = "Punycode.app"
+               BlueprintName = "PunyCocoa"
+               ReferencedContainer = "container:Punycode.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B255A5581500C4800073DF21"
+               BuildableName = "PunycodeTests.xctest"
+               BlueprintName = "PunycodeTests"
+               ReferencedContainer = "container:Punycode.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B255A5581500C4800073DF21"
+               BuildableName = "PunycodeTests.xctest"
+               BlueprintName = "PunycodeTests"
+               ReferencedContainer = "container:Punycode.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B2D4E99208E0191700574ACD"
+            BuildableName = "Punycode.app"
+            BlueprintName = "PunyCocoa"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B2D4E99208E0191700574ACD"
+            BuildableName = "Punycode.app"
+            BlueprintName = "PunyCocoa"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B2D4E99208E0191700574ACD"
+            BuildableName = "Punycode.app"
+            BlueprintName = "PunyCocoa"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Punycode.xcodeproj/xcshareddata/xcschemes/PunycodeTests.xcscheme
+++ b/Example/Punycode.xcodeproj/xcshareddata/xcschemes/PunycodeTests.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B255A5581500C4800073DF21"
+               BuildableName = "PunycodeTests.xctest"
+               BlueprintName = "PunycodeTests"
+               ReferencedContainer = "container:Punycode.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B255A5581500C4800073DF21"
+               BuildableName = "PunycodeTests.xctest"
+               BlueprintName = "PunycodeTests"
+               ReferencedContainer = "container:Punycode.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B255A5581500C4800073DF21"
+            BuildableName = "PunycodeTests.xctest"
+            BlueprintName = "PunycodeTests"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B255A5581500C4800073DF21"
+            BuildableName = "PunycodeTests.xctest"
+            BlueprintName = "PunycodeTests"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B255A5581500C4800073DF21"
+            BuildableName = "PunycodeTests.xctest"
+            BlueprintName = "PunycodeTests"
+            ReferencedContainer = "container:Punycode.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ by Nate Weaver (Wevah)
 http://derailer.org/  
 https://github.com/Wevah/Punycode-Cocoa
 
+[![Build Status](https://travis-ci.org/orkoden/Punycode-Cocoa.svg?branch=master)](https://travis-ci.org/orkoden/Punycode-Cocoa)
+
 A simple punycode/IDNA category on NSString, based on code and documentation from RFC 3492 and RFC 3490.
 
 Use this to convert internationalized domain names (IDN) between Unicode and ASCII.


### PR DESCRIPTION
I did the necessary travis-ci integration steps: created the shared schemes and `.travis.yml` file. I also added the build status to `README.md`.

If you pull this you would have to sign up to [travis-ci](https://travis-ci.org) yourself. It's easy because you can use your github account. Then you select your `Punycode-Cocoa` project and turn the switch to on.
The only other thing you'd have to do then is change the URL for the status image in  `README.md` to point to your travis account.