### PR TITLE
URL Encode the fragment

### DIFF
--- a/Pod/NSStringPunycodeAdditions.m
+++ b/Pod/NSStringPunycodeAdditions.m
@@ -378,8 +378,11 @@ static NSUInteger adapt(unsigned delta, unsigned numpoints, BOOL firsttime) {
 	
 	[ret appendFormat:@"%@%@", [urlParts[@"host"] IDNAEncodedString], path];
 	
-	if (urlParts[@"fragment"])
-		[ret appendFormat:@"#%@", urlParts[@"fragment"]];
+    NSString *fragment = urlParts[@"fragment"];
+    if (fragment) {
+        fragment = (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(NULL, (__bridge CFStringRef)fragment, CFSTR("%"), NULL, kCFStringEncodingUTF8);
+        [ret appendFormat:@"#%@", fragment];
+    }
 			
 	return ret;
 }


### PR DESCRIPTION
This fixes what I was talking about in issue #7 

`https://www.google.co.jp/webhp?<stuff>#q=渋谷` returns nil but
`https://www.google.co.jp/webhp?<stuff>#q=%E6%B8%8B%E8%B0%B7` is OK